### PR TITLE
Enable multiple approval steps within a pod

### DIFF
--- a/pkg/watcher/watcher.go
+++ b/pkg/watcher/watcher.go
@@ -106,7 +106,6 @@ func handlePodEvent(pod *corev1.Pod) {
 			// Bug?? Current/Next step is in Terminated state... right after the approval step ends
 			//       just update Approval whenever the current step is in terminated status
 			handleApprovalStepFinished(pod, &cont)
-			return
 		}
 	}
 }


### PR DESCRIPTION
## Done
- Fixed to handle multiple approval steps within a pod
- It was due to the previous fix (detecting terminated container whenever the container is in `terminated` state)
- Removed `return` to handle multiple approval steps