### PR TITLE
Handle pod deletion event

### DIFF
--- a/pkg/apis/tmax/v1/approval_types.go
+++ b/pkg/apis/tmax/v1/approval_types.go
@@ -11,6 +11,7 @@ const (
 	ResultApproved Result = "Approved"
 	ResultRejected Result = "Rejected"
 	ResultFailed   Result = "Failed"
+	ResultCanceled Result = "Canceled"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!


### PR DESCRIPTION
Fix #15
If a pod is terminating (queued to be deleted) until approved/rejected,
Approval CR is marked as Canceled state and the rest logics are skipped